### PR TITLE
don't let filenames get interpreted as command-line args

### DIFF
--- a/iabak-helper
+++ b/iabak-helper
@@ -31,7 +31,7 @@ download () {
 rundownload () {
 	if [ ! -e ../NOSHUF ] && [ -x /usr/bin/shuf ]; then
 		echo "(Oh good, you have shuf(1)! Randomizing order.. Will take a couple minutes..)"
-		git annex find --print0 --not --copies "$NUMCOPIES" | xargs --no-run-if-empty -0 dirname -z -- | uniq -z | shuf -z | xargs --no-run-if-empty -0 -t git annex get
+		git annex find --print0 --not --copies "$NUMCOPIES" | xargs --no-run-if-empty -0 dirname -z -- | uniq -z | shuf -z | xargs --no-run-if-empty -0 -t git annex get --
 	else
 		git annex get --not --copies "$NUMCOPIES"
 	fi

--- a/iabak-helper
+++ b/iabak-helper
@@ -31,7 +31,7 @@ download () {
 rundownload () {
 	if [ ! -e ../NOSHUF ] && [ -x /usr/bin/shuf ]; then
 		echo "(Oh good, you have shuf(1)! Randomizing order.. Will take a couple minutes..)"
-		git annex find --print0 --not --copies "$NUMCOPIES" | xargs --no-run-if-empty -0 dirname -z | uniq -z | shuf -z | xargs --no-run-if-empty -0 -t git annex get
+		git annex find --print0 --not --copies "$NUMCOPIES" | xargs --no-run-if-empty -0 dirname -z -- | uniq -z | shuf -z | xargs --no-run-if-empty -0 -t git annex get
 	else
 		git annex get --not --copies "$NUMCOPIES"
 	fi


### PR DESCRIPTION
Probably need to do the same thing elsewhere; any place where a filename
is used as a command-line argument to some program we'll have to do much
the same thing. All the common utilities/coreutils use the same --
indicator to separate options from filenames; does git annex? I've never
checked.
