### PR TITLE
bugfix when there is no internet connection

### DIFF
--- a/install-git-annex
+++ b/install-git-annex
@@ -5,7 +5,7 @@ if [ -d git-annex.linux ]; then
 	# if an installed version exists, check the version-number
 	installedVersion=$(./git-annex.linux/git-annex version | grep "version" -m 1 | sed 's/^.*\([0-9]\+\)\.\([0-9]\{8\}\).*$/\2/' | tr '\n' ' ')
 	newVersion=$(wget https://downloads.kitenet.net/git-annex/linux/current/git-annex-standalone-i386.tar.gz.info -o /dev/null -O - | sed 's/.*distributionReleasedate = \([0-9]\{4\}\)-\([0-9]\{2\}\)-\([0-9]\{2\}\).*UTC,.*/\1\2\3/' | tr '\n' ' ')
-	if [ "$installedVersion" -lt "$newVersion" ]; then
+	if [ -n "$newVersion" ]  && [ "$installedVersion" -lt "$newVersion" ]
 		rm -rf git-annex.linux
 	fi
 fi

--- a/install-git-annex
+++ b/install-git-annex
@@ -5,7 +5,7 @@ if [ -d git-annex.linux ]; then
 	# if an installed version exists, check the version-number
 	installedVersion=$(./git-annex.linux/git-annex version | grep "version" -m 1 | sed 's/^.*\([0-9]\+\)\.\([0-9]\{8\}\).*$/\2/' | tr '\n' ' ')
 	newVersion=$(wget https://downloads.kitenet.net/git-annex/linux/current/git-annex-standalone-i386.tar.gz.info -o /dev/null -O - | sed 's/.*distributionReleasedate = \([0-9]\{4\}\)-\([0-9]\{2\}\)-\([0-9]\{2\}\).*UTC,.*/\1\2\3/' | tr '\n' ' ')
-	if [ -n "$newVersion" ]  && [ "$installedVersion" -lt "$newVersion" ]
+	if [ -n "$newVersion" ]  && [ "$installedVersion" -lt "$newVersion" ]; then
 		rm -rf git-annex.linux
 	fi
 fi


### PR DESCRIPTION
$newVersion is empty when there is no internet connection and [ "$installedVersion" -lt "$newVersion" ] fails because $newVersion is not a number
