### PR TITLE
Fall back to a cron job if systemd fails

### DIFF
--- a/install-fsck-service
+++ b/install-fsck-service
@@ -26,8 +26,12 @@ install_systemd () {
 				[Install]
 				WantedBy=default.target
 				EOF
-			"${SYSTEMCTL}" --user daemon-reload
-			"${SYSTEMCTL}" --user enable iabak-cronjob.timer
+			if ! ( "${SYSTEMCTL}" --user daemon-reload && "${SYSTEMCTL}" --user enable iabak-cronjob.timer ); then
+				echo "Your systemd doesn't appear to be configured to run user jobs."
+				echo "Falling back to an old-school cron job."
+				rm -f "${file}.service" "${file}.timer"
+				return 1
+			fi
 			echo "Systemd service iabak-cronjob installed and enabled."
 			echo "*** Note: you may need to run 'loginctl enable-linger $(whoami)' in order for this job to run while you are logged out."
 		else


### PR DESCRIPTION
Currently the script doesn't check to see if systemd is actually usable. systemctl will return nonzero if the user bus is for some reason not usable (ie. if the user dbus is not running, not available etc.)

This makes the script fall back to a cronjob in those cases.
