### PR TITLE
use shared locks around all git commands

### DIFF
--- a/checkoutshard
+++ b/checkoutshard
@@ -23,6 +23,8 @@ case "$(uname)" in
 esac
 export PATH
 
+. ./locks.sh
+
 top="$(pwd)"
 prevshard="$(echo shard* 2>/dev/null | cut -d ' ' -f 1)"
 
@@ -69,19 +71,19 @@ status="$3"
 
 # This is slightly weird way to clone, but it allows using our
 # dedicated ssh key without installing it in ~/.ssh/
-git init "$localdir"
+${GIT} init "$localdir"
 cd "$localdir"
-git config user.name "$(whoami)"
-git config user.email "$(whoami)@iabak"
-git config gc.auto 0
-git annex init
+${GIT} config user.name "$(whoami)"
+${GIT} config user.email "$(whoami)@iabak"
+${GIT} config gc.auto 0
+${GIT_ANNEX} init
 uuid="$(git config annex.uuid)"
 (cd .. && checkssh "$repourl" "$uuid" 2)
 cp -a ../id_rsa .git/annex/id_rsa
 cp -a ../id_rsa.pub .git/annex/id_rsa.pub
-git remote add origin "$repourl"
-git config remote.origin.annex-ssh-options "-i .git/annex/id_rsa"
-git annex sync
+${GIT} remote add origin "$repourl"
+${GIT} config remote.origin.annex-ssh-options "-i .git/annex/id_rsa"
+${GIT} annex sync
 
 # Copy over any user configuration from a previous shard.
 cd "$top"
@@ -89,7 +91,7 @@ if [ -n "$prevshard" ] && [ -d "$prevshard" ]; then
 	for c in annex.diskreserve annex.web-options; do
 		val="$(cd "$prevshard" && git config "$c" || true)"
 		if [ -n "$val" ]; then
-			(cd "$localdir" && git config "$c" "$val")
+			(cd "$localdir" && ${GIT} config "$c" "$val")
 		fi
 	done
 fi

--- a/flock.pl
+++ b/flock.pl
@@ -4,17 +4,77 @@
 use warnings;
 use strict;
 use Fcntl qw(:flock);
+use Getopt::Long qw(:config require_order);
+use Pod::Usage qw(pod2usage);
 # line buffer
 $|=1;
 
-my $file = shift;
-my $cmd = join(" ", @ARGV);
+my $exclusive = 1;
+my $shared = 0;
+my $nonblock = 0;
+my $command = '';
+my $help = '';
+GetOptions ("exclusive|x" => \$exclusive,
+            "shared|x" => \$shared,
+            "nonblock|n" => \$nonblock,
+            "help|h|?" => \$help) or pod2usage(2);
 
-if(!$file || !$cmd) {
-   die("usage: $0 <file> <command> [ <command args>... ]\n");
+my $file = shift;
+if (!$command) {
+  $command = join(" ", @ARGV);
+}
+
+if ($help) {
+  pod2usage(0);
+}
+
+if (!$file || !$command) {
+   pod2usage(3);
 }
 
 open(FH, '>', $file) || die($!);
-flock(FH, LOCK_EX | LOCK_NB) || die($!);
-system($cmd);
+flock(FH,
+      ($shared ? LOCK_SH : LOCK_EX) |
+      ($nonblock ? LOCK_NB : 0)) or die($!);
+system($command);
 flock(FH, LOCK_UN);
+
+__END__
+
+=head1 NAME
+
+flock - stuff
+
+=head1 SYNOPSIS
+
+flock [options] [command arguments ...]
+
+ Options:
+   --help           full help message
+   -x, --exclusive  write lock
+   -s, --shared     read lock
+   -n, --nonblock   non-blocking
+
+=head1 OPTIONS
+
+=over 8
+
+=item B<-x, --exclusive>
+
+Use an exclusive (write) lock. This is the default.
+
+=item B<-s, --shared>
+
+Use a shared (read) lock
+
+=item B<-n, --nonblock>
+
+Use a non-blocking lock
+
+=back
+
+=head1 DESCRIPTION
+
+B<This program> implements those parts of flock(1) which iabak actually uses.
+
+=cut

--- a/iabak-helper
+++ b/iabak-helper
@@ -26,11 +26,7 @@ if [ -e ANNEXGETOPTS ]; then
 	export ANNEXGETOPTS
 fi
 
-if FLOCK=$(which flock); then
-	FLOCK="${FLOCK} -x -n"
-else
-	FLOCK="$(pwd)/flock.pl"
-fi
+. ./locks.sh
 
 pow () {
 	local x=${1:-1} y=${2:-0} result=${3:-1}
@@ -68,7 +64,7 @@ syncshard () {
 	# assumes that pwd is a shard
 	local retries=0
 	while [ ${retries} -lt 5 ]; do
-		if git annex sync; then
+		if ${GITANNEX} sync; then
 			return 0
 		fi
 		retries=$((retries+1))
@@ -99,9 +95,9 @@ download () {
 rundownloaddirs () {
 	if [ ! -e ../NOSHUF ] && [ -x /usr/bin/shuf ] && dirname -z foo >/dev/null 2>&1 ; then
 		echo "(Oh good, you have shuf(1)! Randomizing order.. Will take a couple minutes..)"
-		git annex find --print0 --not --copies "$NUMCOPIES" | xargs --no-run-if-empty -0 dirname -z -- | uniq -z | shuf -z | xargs --no-run-if-empty -n 100 -0 git -c annex.alwayscommit=false annex get $ANNEXGETOPTS --
+		${GITANNEX} find --print0 --not --copies "$NUMCOPIES" | xargs --no-run-if-empty -0 dirname -z -- | uniq -z | shuf -z | xargs --no-run-if-empty -n 100 -0 ${GIT} -c annex.alwayscommit=false annex get $ANNEXGETOPTS --
 	else
-		git annex get --not --copies "$NUMCOPIES" $ANNEXGETOPTS
+		${GITANNEX} get --not --copies "$NUMCOPIES" $ANNEXGETOPTS
 	fi
 }
 
@@ -109,11 +105,11 @@ rundownloadfiles () {
 	echo "Checking for any files that still need to be downloaded..."
 	if [ ! -e ../NOSHUF ] && [ -x /usr/bin/shuf ]; then
 		# don't use dirname here, because in maint mode,
-		# only 1 file from a dir might go missing and we 
+		# only 1 file from a dir might go missing and we
 		# don't want to download the whole dir then
-		git annex find --print0 --not --copies "$NUMCOPIES" | shuf -z | xargs --no-run-if-empty -n 100 -0 git -c annex.alwayscommit=false annex get $ANNEXGETOPTS --
+		${GITANNEX} find --print0 --not --copies "$NUMCOPIES" | shuf -z | xargs --no-run-if-empty -n 100 -0 ${GIT} -c annex.alwayscommit=false annex get $ANNEXGETOPTS --
 	else
-		git annex get --not --copies "$NUMCOPIES" $ANNEXGETOPTS
+		${GITANNEX} get --not --copies "$NUMCOPIES" $ANNEXGETOPTS
 	fi
 }
 
@@ -125,7 +121,7 @@ fsckme () {
 	if [ -z "$FSCKTIMELIMIT" ]; then
 		FSCKTIMELIMIT=5h
 	fi
-	${FLOCK} .git/annex/fullfsck.lock git annex fsck --incremental-schedule 30d --time-limit "$FSCKTIMELIMIT"
+	${FLOCK_EX} .git/annex/fullfsck.lock ${GITANNEX} fsck --incremental-schedule 30d --time-limit "$FSCKTIMELIMIT"
 	fsckresult=$?
 	set -e
 	if [ "$fsckresult" -eq 101 ]; then
@@ -141,7 +137,7 @@ fastfsck () {
 	if [ ! -d .empty ]; then
 		mkdir .empty
 	fi
-	git annex fsck --fast .empty --quiet >/dev/null 2>/dev/null || true
+	${GITANNEX} fsck --fast .empty --quiet >/dev/null 2>/dev/null || true
 	syncshard || echo "Warning: failed to sync this shard; fsck results not recorded on server"
 }
 
@@ -164,7 +160,7 @@ maint () {
 }
 
 periodicsync () {
-	${FLOCK} .git/annex/iasyncer.lock ../iabak-hourlysync || true
+	(cd .. && ${FLOCK_EX} .git/annex/iasyncer.lock ./iabak-hourlysync) || true
 }
 
 outofspace () {
@@ -176,7 +172,7 @@ stillhavespace () {
 	prevshard="$(echo shard* 2>/dev/null | cut -d ' ' -f 1)"
 
 	if [ -n "$prevshard" ]; then
-		reserve="$(cd "$prevshard" && git config annex.diskreserve || true)"
+		reserve="$(cd "$prevshard" && ${GIT} config annex.diskreserve || true)"
 		if [ -n "$reserve" ] && outofspace "$reserve"; then
 			false
 		else
@@ -201,18 +197,18 @@ setup () {
 			echo "not enough diskspace to reserve"
 			setup
 		else
-			git config annex.diskreserve "$reserve"
+			${GIT} config annex.diskreserve "$reserve"
 		fi
 	fi
 }
 
 installgitannex () {
-	${FLOCK} .iabak-install-git-annex ./install-git-annex || true
+	${FLOCK_EX} .iabak-install-git-annex ./install-git-annex || true
 }
 
 installfsckservice () {
 	if [ ! "$CRONJOB" ]; then
-		${FLOCK} ./iabak-install-fsck-service ./install-fsck-service || true
+		${FLOCK_EX} ./iabak-install-fsck-service ./install-fsck-service || true
 	fi
 }
 

--- a/iabak-hourlysync
+++ b/iabak-hourlysync
@@ -1,9 +1,11 @@
 #!/bin/sh
 set -e
 
+. ./locks.sh
+
 echo $$ > .git/iabak-hourlysync.pid
 
 # OSX has a really stupid sleep command; 1h won't work there.
 while sleep 3600; do
-	git annex sync || true
+	${GIT_ANNEX} sync || true
 done

--- a/locks.sh
+++ b/locks.sh
@@ -1,0 +1,9 @@
+if ! FLOCK=$(which flock); then
+	FLOCK="$(pwd)/flock.pl"
+fi
+
+FLOCK_SH="${FLOCK} -s"
+FLOCK_EX="${FLOCK} -x"
+
+GIT="${FLOCK_SH} $(pwd)/.iabak-install-git-annex git"
+GITANNEX="${GIT} annex"


### PR DESCRIPTION
This prevents the helper and the cronjob from removing git-annex (to
install a newer one) while the other is using it.
