### PR TITLE
Fix closing conditional bracket

### DIFF
--- a/iabak-helper
+++ b/iabak-helper
@@ -183,7 +183,7 @@ periodicsync () {
 
 outofspace () {
 	reserve="$1"
-	if [ which numfmt >/dev/null 2>&1]; then
+	if [ which numfmt >/dev/null 2>&1 ]; then
             [ $(df -Ph . | tail -1 | awk '{print $4}' | numfmt --from=si) -lt $(echo $reserve | numfmt --from=si) ]
         else
             [ $(bytesFromSize $(df -Ph . | tail -1 | awk '{print $4}')) -lt $(bytesFromSize ${reserve}) ]


### PR DESCRIPTION
Certain versions of bash do not like having the '1' in '2>&1' directly adjacent to the closing bracket of the conditional statement
